### PR TITLE
feat: enable sentry analytics option

### DIFF
--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -148,13 +148,13 @@ deployers:
 
 ## Sentry Analytics
 
-The app will optionally collect analytics data to send to Sentry. This functionality is opt-in and disabled by default. This data helps us identify UI bugs and provide the best possible user experience.
+The app will optionally collect analytics data to send to Sentry. This functionality is opt-out and enabled by default. This data helps us identify UI bugs and provide the best possible user experience.
 
 Optional fields:
-- `sentry` (defaults to 'false')
+- `sentry` (defaults to 'true')
 
 ```
-sentry: true
+sentry: false
 ```
 
 ## Front matter yaml

--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -148,7 +148,7 @@ deployers:
 
 ## Sentry Analytics
 
-The app will optionally collect analytics data to send to Sentry. This functionality is opt-in and disabled by default. If you are willing to share your analytics data, it will help us identify UI bugs and provide the best possible user experience.
+The app will optionally collect analytics data to send to Sentry. This functionality is opt-in and disabled by default. This data helps us identify UI bugs and provide the best possible user experience.
 
 Optional fields:
 - `sentry` (defaults to 'false')

--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -146,6 +146,17 @@ deployers:
     network: polygon
 ```
 
+## Sentry Analytics
+
+The app will optionally collect analytics data to send to Sentry. This functionality is disabled by default and opt-in. If you are willing to share your analytics data it helps us to develop the and provide the best user experience. 
+
+Optional fields:
+- `sentry` (defaults to 'false')
+
+```
+sentry: true
+```
+
 ## Front matter yaml
 
 This yaml is NOT arbitrary across the GUI. It only makes sense when coupled to some specific rainlang, which also makes the most sense when provided as frontmatter that can be directly parsed, composed and bound by the `dotrain` tool.

--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -148,7 +148,7 @@ deployers:
 
 ## Sentry Analytics
 
-The app will optionally collect analytics data to send to Sentry. This functionality is disabled by default and opt-in. If you are willing to share your analytics data it helps us to develop the and provide the best user experience. 
+The app will optionally collect analytics data to send to Sentry. This functionality is opt-in and disabled by default. If you are willing to share your analytics data, it will help us identify UI bugs and provide the best possible user experience.
 
 Optional fields:
 - `sentry` (defaults to 'false')


### PR DESCRIPTION
Adds a config property `sentry` (see https://github.com/rainlanguage/rain.orderbook/pull/457)