### PR TITLE
Update network rpc to be a list instead of a single url

### DIFF
--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -20,7 +20,7 @@ Need to define many networks that can be switched between at any time. Generally
 
 Required fields:
 
-- `rpc_list`
+- `rpcs`
 - `chain-id`
 
 Optional fields:
@@ -40,14 +40,14 @@ https://besu.hyperledger.org/23.4.0/public-networks/concepts/network-and-chain-i
 ```
 networks:
   mainnet:
-    rpc_list: 
+    rpcs: 
       - https://eth.llamarpc.com
       - https://rpc.ankr.com/eth
     chain-id: 0x1
 
   classic:
     label: ETH classic
-    rpc_list: 
+    rpcs: 
       - https://etc.rivet.link
     chain-id: 61
     network-id: 1

--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -20,7 +20,7 @@ Need to define many networks that can be switched between at any time. Generally
 
 Required fields:
 
-- `rpc`
+- `rpc_list`
 - `chain-id`
 
 Optional fields:
@@ -40,12 +40,15 @@ https://besu.hyperledger.org/23.4.0/public-networks/concepts/network-and-chain-i
 ```
 networks:
   mainnet:
-    rpc: https://eth.llamarpc.com
+    rpc_list: 
+      - https://eth.llamarpc.com
+      - https://rpc.ankr.com/eth
     chain-id: 0x1
 
   classic:
     label: ETH classic
-    rpc: https://etc.rivet.link
+    rpc_list: 
+      - https://etc.rivet.link
     chain-id: 61
     network-id: 1
     currency: ETC


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/specs/issues/26

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/specs/issues/26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated network configuration examples to use the new `rpc_list` field, supporting multiple RPC endpoints in YAML.
  - Replaced references to the `rpc` field with `rpc_list` throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->