### PR TITLE
Add vaultless field to order input/output spec

### DIFF
--- a/ob-yaml.md
+++ b/ob-yaml.md
@@ -279,7 +279,32 @@ Optional fields:
 - `deployer` (defaults to network deployer if unambiguous, otherwise required)
 - `orderbook` (defaults to network orderbook if unambiguous, otherwise required)
 
-```
+#### Input/Output fields
+
+Required fields:
+- `token` (foreign key into the tokens mapping)
+
+Optional fields:
+- `vault-id` (vault identifier, generates random if omitted and not vaultless)
+- `vaultless` (boolean, default `false`) - when `true`, uses wallet directly instead of vault
+
+#### Vaultless mode
+
+When `vaultless: true`, the order uses the owner's wallet directly instead of a vault:
+- **Vaultless inputs**: Tokens received are sent directly to the owner's wallet
+- **Vaultless outputs**: Tokens given are pulled directly from the owner's wallet (requires approval)
+- **Hybrid orders**: Each input/output can independently be vaultless or vault-based
+
+##### Validation rules
+
+| Scenario | Result |
+|----------|--------|
+| `vaultless: true` | Valid - uses wallet directly |
+| `vaultless: true` + `vault-id: X` | Error: "Using vault-id is not allowed in vaultless mode" |
+| `vault-id: 0` | Error: "Invalid vault-id value. For vaultless mode use vaultless: true" |
+| `vaultless: false` or omitted | Uses `vault-id` if specified, otherwise generates random |
+
+```yaml
 orders:
   dca-eth:
     inputs:
@@ -305,6 +330,22 @@ orders:
         vault-id: 99
       - token: polygon-usdt
         vault-id: 0xabcd
+  vaultless-order:
+    inputs:
+      - token: eth-weth
+        vaultless: true
+    outputs:
+      - token: eth-usdc
+        vault-id: 1
+  hybrid-order:
+    inputs:
+      - token: eth-weth
+        vaultless: true
+    outputs:
+      - token: eth-usdc
+        vaultless: true
+      - token: eth-dai
+        vault-id: 0x123
 ```
 
 ### front matter scenarios


### PR DESCRIPTION
## Motivation                                                                                                                            
                                                                                                                                           
  Document the new `vaultless` field for order inputs/outputs in the YAML spec. This field enables direct wallet-based trading in V6       
  orderbook.                                                                                                                                                                                                                                               
                                                                                                                                           
  Parent issue: https://github.com/rainlanguage/rain.orderbook/issues/2402                                                                 
                                                                                                                                           
  ## Solution                                                                                                                              
                                                                                                                                           
  Added documentation to `ob-yaml.md` for the `vaultless` field:                                                                           
                                                                                                                                           
  - **Input/Output fields section**: Documents required (`token`) and optional (`vault-id`, `vaultless`) fields                            
  - **Vaultless mode section**: Explains behavior:                                                                                         
    - Vaultless inputs: tokens received go directly to owner's wallet                                                                      
    - Vaultless outputs: tokens given are pulled from owner's wallet (requires approval)                                                   
    - Hybrid orders supported (mix of vaultless and vault-based)                                                                           
  - **Validation rules table**: Covers error cases for `vault-id: 0` and combining `vaultless` with `vault-id`                             
  - **Examples**: Added `vaultless-order` and `hybrid-order` examples                                                                      
                                                                                                                                           
  ## Checks                                                                                                                                
                                                                                                                                           
  By submitting this for review, I'm confirming I've done the following:                                                                   
  - [x] made this PR as small as possible                                                                                                  
  - [ ] unit-tested any new functionality                                                                                                  
  - [x] linked any relevant issues or PRs                                                                                                  
  - [ ] included screenshots (if this involves a front-end change)
  
  fixes #43 